### PR TITLE
feat: add kill manager command

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,12 @@
         "icon": "$(debug-restart)"
       },
       {
+        "command": "winccoa.manager.kill",
+        "title": "Kill Manager",
+        "category": "WinCC OA",
+        "icon": "$(close)"
+      },
+      {
         "command": "winccoa.manager.delete",
         "title": "Delete Manager",
         "category": "WinCC OA",
@@ -283,6 +289,11 @@
           "command": "winccoa.manager.stop",
           "when": "view == winccoa.managerView && viewItem == manager",
           "group": "inline@4"
+        },
+        {
+          "command": "winccoa.manager.kill",
+          "when": "view == winccoa.managerView && viewItem =~ /^manager/",
+          "group": "manager@0"
         },
         {
           "command": "winccoa.manager.delete",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -231,6 +231,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<WinCCO
         );
 
         context.subscriptions.push(
+            vscode.commands.registerCommand('winccoa.manager.kill', async (item: unknown) => {
+                if (hasManagerData(item)) {
+                    await managerTreeProvider.killManager(item.managerData);
+                }
+            }),
+        );
+
+        context.subscriptions.push(
             vscode.commands.registerCommand('winccoa.manager.delete', async (item: unknown) => {
                 if (hasManagerData(item)) {
                     await managerTreeProvider.deleteManager(item);

--- a/src/views/managerTreeProvider.ts
+++ b/src/views/managerTreeProvider.ts
@@ -273,6 +273,29 @@ export class ManagerTreeProvider implements vscode.TreeDataProvider<ManagerItem>
         }
     }
 
+    async killManager(managerData: ManagerDisplayData): Promise<void> {
+        if (!this.currentProjectId) {
+            vscode.window.showErrorMessage('No project selected');
+            return;
+        }
+
+        try {
+            ExtensionOutputChannel.info(
+                'ManagerTreeProvider',
+                `Killing manager ${managerData.idx} for project: ${this.currentProjectId}`,
+            );
+            const result = await this.pmon.killManager(this.currentProjectId, managerData.idx);
+            if (result === 0) {
+                vscode.window.showInformationMessage(`✓ Manager killed successfully`);
+            } else {
+                vscode.window.showErrorMessage(`Failed to kill manager (error code: ${result})`);
+            }
+            await this.loadManagers();
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to kill manager: ${error}`);
+        }
+    }
+
     async restartManager(managerData: ManagerDisplayData): Promise<void> {
         if (!this.currentProjectId) {
             vscode.window.showErrorMessage('No project selected');


### PR DESCRIPTION
## Add Kill Manager Command

Closes #34

### Summary
Implements a new "Kill Manager" command that allows forcefully terminating WinCC OA managers via right-click context menu in the Manager View.

### Changes
- Added `winccoa.manager.kill` command with close icon
- Registered command in extension activation
- Implemented `killManager()` method in `ManagerTreeProvider` using the existing `pmon.killManager()` from npm-winccoa-core
- Added context menu entry in Manager View

### Modified Files
- `package.json` - Command definition and context menu configuration
- `src/extension.ts` - Command registration
- `src/views/managerTreeProvider.ts` - Implementation of killManager method

### Implementation Details
The kill command follows the same pattern as existing manager control commands (start/stop/restart):
- Validates project selection
- Calls `pmon.killManager(projectId, managerIndex)` from npm-winccoa-core
- Shows success/error notifications
- Refreshes manager list after operation
- Includes proper logging via ExtensionOutputChannel

### Testing
- ✅ Compiled successfully without errors
- ✅ Command appears in context menu when right-clicking managers
- ✅ Uses the verified `killManager()` function from npm-winccoa-core library

### Usage
Right-click on any manager in the Manager View and select "Kill Manager" to forcefully terminate the manager process.