### PR TITLE
fix: update old repository URLs from vscode-winccoa-control to vscode-winccoa-project-admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,4 +212,4 @@ This core library is used by:
 ---
 <center>Made with ❤️ for and by the WinCC OA community</center>
 
-[GitHub](https://github.com/winccoa-tools-pack/vscode-winccoa-control) • [Issues](https://github.com/winccoa-tools-pack/vscode-winccoa-control/issues) • [WinCC OA Docs](https://www.winccoa.com)
+[GitHub](https://github.com/winccoa-tools-pack/vscode-winccoa-project-admin) • [Issues](https://github.com/winccoa-tools-pack/vscode-winccoa-project-admin/issues) • [WinCC OA Docs](https://www.winccoa.com)


### PR DESCRIPTION
## Summary
- Replace all references to the old repository name `vscode-winccoa-control` with the current name `vscode-winccoa-project-admin` in README.md
- The repository was renamed but documentation links were not updated

## Related
- Part of documentation review tracked in winccoa-tools-pack/.github
